### PR TITLE
Add snapshot view modes and fix Windows terminal input

### DIFF
--- a/src/mcp_terminal/api/endpoints.py
+++ b/src/mcp_terminal/api/endpoints.py
@@ -6,8 +6,9 @@ Provides REST API for managing terminal sessions.
 
 import asyncio
 import logging
+from typing import Literal, Optional
 
-from fastapi import APIRouter, HTTPException, WebSocket, WebSocketDisconnect
+from fastapi import APIRouter, HTTPException, Query, WebSocket, WebSocketDisconnect
 
 from ..models import (
     TerminalCreate,
@@ -25,7 +26,13 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/terminals", tags=["terminals"])
 
 
-@router.post("/", response_model=TerminalResponse, status_code=201)
+@router.post(
+    "/",
+    response_model=TerminalResponse,
+    status_code=201,
+    operation_id="create_terminal",
+    summary="Create new terminal session",
+)
 async def create_terminal(
     request: TerminalCreate,
     manager: TerminalManagerDep,
@@ -57,7 +64,12 @@ async def create_terminal(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.get("/", response_model=TerminalListResponse)
+@router.get(
+    "/",
+    response_model=TerminalListResponse,
+    operation_id="list_terminals",
+    summary="List all terminals",
+)
 async def list_terminals(manager: TerminalManagerDep):
     """
     List all active terminal sessions.
@@ -78,16 +90,44 @@ async def list_terminals(manager: TerminalManagerDep):
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.get("/{terminal_id}/snapshot", response_model=TerminalSnapshot)
-async def get_terminal_snapshot(terminal_id: str, manager: TerminalManagerDep):
+@router.get(
+    "/{terminal_id}/snapshot",
+    response_model=TerminalSnapshot,
+    operation_id="get_terminal_snapshot",
+    summary="Get terminal visual snapshot",
+)
+async def get_terminal_snapshot(
+    terminal_id: str,
+    manager: TerminalManagerDep,
+    view_mode: Literal["full", "last_line", "last_n_lines", "cursor_area"] = Query(
+        default="full",
+        description="View mode: 'full' (entire screen), 'last_line' (only last line), 'last_n_lines' (last N lines), 'cursor_area' (lines around cursor)",
+    ),
+    n_lines: int = Query(
+        default=10,
+        ge=1,
+        le=200,
+        description="Number of lines for 'last_n_lines' mode",
+    ),
+    context_lines: int = Query(
+        default=3,
+        ge=1,
+        le=20,
+        description="Context lines before/after cursor for 'cursor_area' mode",
+    ),
+):
     """
     Get visual snapshot of terminal.
 
     Shows what a human would see on the terminal screen.
+    Supports different view modes to reduce context for LLMs.
 
     Args:
         terminal_id: Terminal session ID
         manager: Terminal manager dependency
+        view_mode: View mode to use (full, last_line, last_n_lines, cursor_area)
+        n_lines: Number of lines for last_n_lines mode
+        context_lines: Context lines for cursor_area mode
 
     Returns:
         Terminal snapshot with display, cursor, and metadata
@@ -95,7 +135,8 @@ async def get_terminal_snapshot(terminal_id: str, manager: TerminalManagerDep):
     try:
         # Add 5 second timeout
         snapshot = await asyncio.wait_for(
-            manager.get_snapshot(terminal_id), timeout=5.0
+            manager.get_snapshot(terminal_id, view_mode, n_lines, context_lines),
+            timeout=5.0,
         )
         return TerminalSnapshot(**snapshot)
     except asyncio.TimeoutError:
@@ -107,7 +148,12 @@ async def get_terminal_snapshot(terminal_id: str, manager: TerminalManagerDep):
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.post("/{terminal_id}/input", response_model=TerminalResponse)
+@router.post(
+    "/{terminal_id}/input",
+    response_model=TerminalResponse,
+    operation_id="send_terminal_input",
+    summary="Send input to terminal",
+)
 async def send_terminal_input(
     terminal_id: str,
     request: TerminalInput,
@@ -117,6 +163,19 @@ async def send_terminal_input(
     Send input to terminal session.
 
     Use this to send commands, keystrokes, or any input to the terminal.
+
+    Special characters:
+    - Use \\n for newline (automatically converted to \\r\\n on Windows)
+    - Use \\x1b for ESC key (exit insert mode in vim, etc.)
+    - Use \\x03 for Ctrl+C (interrupt process)
+    - Use \\x04 for Ctrl+D (EOF/logout)
+    - Other control characters: \\x01-\\x1F
+
+    Examples:
+    - Send command: "echo hello\\n"
+    - Exit vim insert mode: "\\x1b"
+    - Vim command: "\\x1b:wq\\n"
+    - Interrupt process: "\\x03"
 
     Args:
         terminal_id: Terminal session ID
@@ -143,7 +202,12 @@ async def send_terminal_input(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.put("/{terminal_id}/resize", response_model=TerminalResponse)
+@router.put(
+    "/{terminal_id}/resize",
+    response_model=TerminalResponse,
+    operation_id="resize_terminal",
+    summary="Resize terminal window",
+)
 async def resize_terminal(
     terminal_id: str,
     request: TerminalResize,
@@ -177,7 +241,12 @@ async def resize_terminal(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.delete("/{terminal_id}", response_model=TerminalResponse)
+@router.delete(
+    "/{terminal_id}",
+    response_model=TerminalResponse,
+    operation_id="close_terminal",
+    summary="Close and cleanup terminal",
+)
 async def close_terminal(terminal_id: str, manager: TerminalManagerDep):
     """
     Close terminal session.

--- a/src/mcp_terminal/core/terminal/buffer.py
+++ b/src/mcp_terminal/core/terminal/buffer.py
@@ -157,3 +157,101 @@ class TerminalBuffer:
         if 0 <= row < self.rows:
             return self.screen.display[row]
         return ""
+
+    def get_last_lines(self, n: int) -> List[str]:
+        """
+        Get last N lines from display.
+
+        Args:
+            n: Number of lines to retrieve from bottom
+
+        Returns:
+            List of last N lines
+        """
+        if n <= 0:
+            return []
+        if n >= self.rows:
+            return self.get_display_lines()
+
+        start_row = max(0, self.rows - n)
+        return [self.screen.display[i] for i in range(start_row, self.rows)]
+
+    def get_last_line(self) -> str:
+        """
+        Get the last line from display.
+
+        Returns:
+            Last line content as string
+        """
+        return self.screen.display[self.rows - 1] if self.rows > 0 else ""
+
+    def get_cursor_area(self, context_lines: int = 3) -> Dict[str, any]:
+        """
+        Get lines around the cursor position.
+
+        Args:
+            context_lines: Number of lines before and after cursor
+
+        Returns:
+            Dict with lines, cursor info, and range
+        """
+        cursor_row, cursor_col = self.get_cursor_position()
+
+        start_row = max(0, cursor_row - context_lines)
+        end_row = min(self.rows, cursor_row + context_lines + 1)
+
+        lines = [self.screen.display[i] for i in range(start_row, end_row)]
+
+        return {
+            "lines": lines,
+            "cursor": {"row": cursor_row, "col": cursor_col},
+            "range": {"start_row": start_row, "end_row": end_row},
+            "total_lines": len(lines),
+        }
+
+    def get_snapshot_with_mode(
+        self, view_mode: str = "full", n_lines: int = 10, context_lines: int = 3
+    ) -> Dict[str, any]:
+        """
+        Get snapshot with specific view mode.
+
+        Args:
+            view_mode: View mode - "full", "last_line", "last_n_lines", "cursor_area"
+            n_lines: Number of lines for "last_n_lines" mode
+            context_lines: Context lines for "cursor_area" mode
+
+        Returns:
+            Dict containing display data based on view mode
+        """
+        cursor_row, cursor_col = self.get_cursor_position()
+
+        if view_mode == "last_line":
+            lines = [self.get_last_line()]
+            display = lines[0]
+            range_info = {"start_row": self.rows - 1, "end_row": self.rows}
+
+        elif view_mode == "last_n_lines":
+            lines = self.get_last_lines(n_lines)
+            display = "\n".join(lines)
+            start_row = max(0, self.rows - n_lines)
+            range_info = {"start_row": start_row, "end_row": self.rows}
+
+        elif view_mode == "cursor_area":
+            cursor_data = self.get_cursor_area(context_lines)
+            lines = cursor_data["lines"]
+            display = "\n".join(lines)
+            range_info = cursor_data["range"]
+
+        else:  # "full" or default
+            lines = self.get_display_lines()
+            display = self.get_display()
+            range_info = {"start_row": 0, "end_row": self.rows}
+
+        return {
+            "display": display,
+            "lines": lines,
+            "cursor": {"row": cursor_row, "col": cursor_col},
+            "size": {"rows": self.rows, "cols": self.cols},
+            "view_mode": view_mode,
+            "range": range_info,
+        }

--- a/src/mcp_terminal/core/terminal/manager.py
+++ b/src/mcp_terminal/core/terminal/manager.py
@@ -171,36 +171,47 @@ class TerminalManager:
 
         await session.write(data)
 
-    async def get_snapshot(self, terminal_id: str) -> Dict:
+    async def get_snapshot(
+        self,
+        terminal_id: str,
+        view_mode: str = "full",
+        n_lines: int = 10,
+        context_lines: int = 3,
+    ) -> Dict:
         """
-        Get cached visual snapshot of terminal.
+        Get cached visual snapshot of terminal with optional view mode.
 
         Returns the most recent snapshot from the buffer (updated via WebSocket).
 
         Args:
             terminal_id: Terminal ID
+            view_mode: View mode - "full", "last_line", "last_n_lines", "cursor_area"
+            n_lines: Number of lines for "last_n_lines" mode
+            context_lines: Context lines for "cursor_area" mode
 
         Returns:
             Snapshot dict with display, cursor, etc.
         """
         session = self.sessions.get(terminal_id)
-        snapshot_buffer = self.snapshot_buffers.get(terminal_id)
+        buffer = self.buffers.get(terminal_id)
 
-        if not session or snapshot_buffer is None:
+        if not session or not buffer:
             raise ValueError(f"Terminal not found: {terminal_id}")
 
-        # Get most recent snapshot from buffer, or create empty if none
-        if snapshot_buffer:
-            snapshot = dict(snapshot_buffer[-1])  # Copy last snapshot
+        # Get snapshot with specified view mode
+        if view_mode != "full":
+            # Use buffer's view mode method for filtered views
+            snapshot = buffer.get_snapshot_with_mode(view_mode, n_lines, context_lines)
         else:
-            # No snapshots yet, return empty
-            snapshot = {
-                "display": "",
-                "lines": [],
-                "cursor": {"row": 0, "col": 0},
-                "size": {"rows": session.rows, "cols": session.cols},
-            }
+            # Use cached snapshot for full view
+            snapshot_buffer = self.snapshot_buffers.get(terminal_id)
+            if snapshot_buffer:
+                snapshot = dict(snapshot_buffer[-1])  # Copy last snapshot
+            else:
+                # No snapshots yet, get from buffer directly
+                snapshot = buffer.get_snapshot()
 
+        # Add metadata
         snapshot["terminal_id"] = terminal_id
         snapshot["is_alive"] = session.is_alive
         snapshot["created_at"] = session.created_at.isoformat()

--- a/src/mcp_terminal/core/terminal/session.py
+++ b/src/mcp_terminal/core/terminal/session.py
@@ -97,6 +97,20 @@ class TerminalSession:
         try:
             import asyncio
 
+            # Decode escape sequences (e.g., \x1b for ESC, \x03 for Ctrl+C)
+            # This allows sending control characters from the API
+            try:
+                data = data.encode().decode('unicode-escape')
+            except:
+                # If decoding fails, use original data
+                pass
+
+            # Convert line endings for Windows compatibility
+            # Windows cmd.exe expects \r\n (CRLF) for proper command execution
+            if os.name == "nt":  # Windows
+                # Replace \n with \r\n for proper command execution
+                data = data.replace("\n", "\r\n")
+
             # Run blocking write in executor with 5 second timeout
             # terminado expects string, not bytes
             loop = asyncio.get_event_loop()

--- a/src/mcp_terminal/models/__init__.py
+++ b/src/mcp_terminal/models/__init__.py
@@ -10,6 +10,7 @@ from .terminal import (
     TerminalResponse,
     TerminalSize,
     TerminalSnapshot,
+    ViewRange,
 )
 
 __all__ = [
@@ -22,4 +23,5 @@ __all__ = [
     "TerminalResponse",
     "TerminalSize",
     "TerminalSnapshot",
+    "ViewRange",
 ]

--- a/src/mcp_terminal/models/terminal.py
+++ b/src/mcp_terminal/models/terminal.py
@@ -34,6 +34,13 @@ class TerminalSize(BaseModel):
     cols: int = Field(description="Terminal width")
 
 
+class ViewRange(BaseModel):
+    """View range information."""
+
+    start_row: int = Field(description="Starting row of the view")
+    end_row: int = Field(description="Ending row of the view")
+
+
 class TerminalSnapshot(BaseModel):
     """Terminal visual snapshot."""
 
@@ -44,6 +51,12 @@ class TerminalSnapshot(BaseModel):
     size: TerminalSize = Field(description="Terminal size")
     is_alive: bool = Field(description="Whether terminal is running")
     created_at: str = Field(description="Terminal creation timestamp")
+    view_mode: Optional[str] = Field(
+        default="full", description="View mode used for this snapshot"
+    )
+    range: Optional[ViewRange] = Field(
+        default=None, description="Row range included in this view"
+    )
 
 
 class TerminalResponse(BaseModel):


### PR DESCRIPTION
## Summary
- Added 4 view modes for terminal snapshots to reduce LLM context consumption
- Fixed critical Windows terminal input issues (commands not executing)
- Added support for control characters (ESC, Ctrl+C, etc.)

## Features Added
### View Modes
- `full` - Complete terminal screen (default)
- `last_line` - Only the last line
- `last_n_lines` - Last N lines (configurable via query param)
- `cursor_area` - Lines around cursor with configurable context

### Benefits
- Reduces token usage for LLMs by showing only relevant terminal content
- Enables efficient monitoring of long-running processes
- Better UX for interactive editing sessions

## Bug Fixes
### Windows Command Execution
- Fixed commands not executing by converting `\n` to `\r\n` on Windows
- Full-screen editors (vim, nano) now work correctly

### Control Characters Support
- Added unicode-escape decoding for control characters
- ESC (`\x1b`) - Exit insert mode in vim
- Ctrl+C (`\x03`) - Interrupt processes
- Ctrl+D (`\x04`) - EOF/logout
- All control characters `\x01-\x1F` now supported

## Implementation Details
- **buffer.py**: Added view mode methods
- **manager.py**: Updated snapshot retrieval with view mode support
- **session.py**: Added escape sequence decoding + Windows line ending conversion
- **endpoints.py**: Added query parameters and enhanced documentation
- **models/terminal.py**: Added ViewRange model

## Test Plan
- [x] Tested all 4 view modes with terminal snapshots
- [x] Tested command execution on Windows
- [x] Tested vim editing with ESC key
- [x] Tested multiple commands in sequence
- [x] Verified API documentation clarity

🤖 Generated with [Claude Code](https://claude.com/claude-code)